### PR TITLE
Improve Japanese token handling and SEO title matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-"# seoscraper" 
-"# seoscraper" 
+# seoscraper
+
+Utility helpers for working with Japanese text and SEO titles.
+
+## Features
+
+- `encode_text`/`decode_tokens` wrap [tiktoken](https://github.com/openai/tiktoken)
+  and normalise text so that mojibake like `�` does not appear.
+- `seo_title_similarity` performs fuzzy matching between an SEO title and
+  article text instead of relying on an exact match.
+
+## Testing
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+tiktoken
+ftfy

--- a/test_text_utils.py
+++ b/test_text_utils.py
@@ -1,0 +1,22 @@
+from text_utils import encode_text, decode_tokens, seo_title_similarity
+
+
+def test_round_trip_japanese_text():
+    text = "兵庫県尼崎市"
+    tokens = encode_text(text)
+    decoded = decode_tokens(tokens)
+    assert decoded == text
+
+
+def test_encode_decode_removes_replacement_char():
+    garbled = "�庫県尼崎市"
+    tokens = encode_text(garbled)
+    decoded = decode_tokens(tokens)
+    assert "�" not in decoded
+
+
+def test_seo_title_similarity_fuzzy():
+    title = "兵庫県尼崎市での作業"
+    text = "兵庫県尼崎市の作業所を紹介します。"
+    score = seo_title_similarity(title, text)
+    assert 0.5 < score < 1.0

--- a/text_utils.py
+++ b/text_utils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+import difflib
+
+import tiktoken
+from ftfy import fix_text
+
+
+def _clean_text(text: str) -> str:
+    """Normalize text and drop unknown replacement chars.
+
+    Using ftfy handles common encoding issues and removing the Unicode
+    replacement character prevents mojibake like "�" from appearing in the
+    output.
+    """
+    return fix_text(text).replace("\ufffd", "")
+
+
+def encode_text(text: str, encoding_name: str = "cl100k_base") -> List[int]:
+    """Encode text into tokens after cleaning it."""
+    enc = tiktoken.get_encoding(encoding_name)
+    return enc.encode(_clean_text(text))
+
+
+def decode_tokens(tokens: Iterable[int], encoding_name: str = "cl100k_base") -> str:
+    """Decode tokens back to text, ensuring the result is clean UTF-8."""
+    enc = tiktoken.get_encoding(encoding_name)
+    text = enc.decode(list(tokens))
+    return _clean_text(text)
+
+
+def seo_title_similarity(title: str, text: str) -> float:
+    """Return a fuzzy similarity score between an SEO title and text.
+
+    SequenceMatcher provides a ratio in [0, 1] that measures how similar two
+    strings are without requiring an exact match, which is useful for
+    comparing titles to content.
+    """
+    return difflib.SequenceMatcher(None, _clean_text(title), _clean_text(text)).ratio()
+


### PR DESCRIPTION
## Summary
- normalize and clean Japanese text before encoding with tiktoken
- add fuzzy SEO title similarity helper
- document helpers and add tests

## Testing
- `python -m py_compile text_utils.py test_text_utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a43b8804f4832c9dd63a569eae10da