### PR TITLE
Improve analysis output and ensure top-k results

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * 調査結果を CSV / JSON 形式で保存可能
 * Flask を用いた HTML Web UI（ポート5000）に対応
 * 出現頻度が高すぎる共通サブ文字列や検索語・短い仮名列を自動除外し分析の信頼性を向上
+* 共通サブ文字列ごとの出現割合を表示し、重要度を直感的に評価可能
 * tiktoken によるトークン列分析モード（デフォルト）を搭載
 * トークンと文字列を組み合わせたハイブリッド分析で高精度な共通判定
 * スレッド並列により検索と取得を高速化（`--workers` で制御、デフォルト10）
@@ -92,7 +93,7 @@ robots.txt: あり
 2025-08-12 15:20:05 INFO: OK https://en.wikipedia.org/wiki/OpenAI | title="OpenAI - Wikipedia" robots=True
 2025-08-12 15:20:05 INFO: Summary: hits=3, collected=3, skipped=0
 2025-08-12 15:20:05 INFO: Top 15 COMMON BODY TEXTS:
-2025-08-12 15:20:05 INFO: [BODY 2] 'OpenAI, Inc. は米国の人工知能 (AI) ...'
+2025-08-12 15:20:05 INFO: [BODY 2 / 67%] 'OpenAI, Inc. は米国の人工知能 (AI) ...'
 2025-08-12 15:20:05 INFO: Top 15 COMMON SEO TITLES:
 2025-08-12 15:20:05 INFO: [TITLE 2] 'OpenAI - Wikipedia'
 ```

--- a/scraper.py
+++ b/scraper.py
@@ -666,30 +666,35 @@ def main():
 
         # ローカル再集計（top-k 変更だけなら超高速）
         if args.analysis_mode == 'char':
-            common_subs = common_substrings_rank_from_norm(
+            raw_subs = common_substrings_rank_from_norm(
                 norm_texts,
                 min_len=3,
                 max_len=12,
-                top_k=args.rank_k,
+                top_k=args.rank_k * 3,
                 max_doc_ratio=args.max_common_ratio,
             )
         elif args.analysis_mode == 'hybrid':
-            common_subs = hybrid_common_rank_from_norm(
+            raw_subs = hybrid_common_rank_from_norm(
                 norm_texts,
                 min_len=3,
                 max_len=12,
-                top_k=args.rank_k,
+                top_k=args.rank_k * 3,
                 max_doc_ratio=args.max_common_ratio,
             )
         else:
-            common_subs = common_tokens_rank_from_norm(
+            raw_subs = common_tokens_rank_from_norm(
                 norm_texts,
                 min_len=3,
                 max_len=12,
-                top_k=args.rank_k,
+                top_k=args.rank_k * 3,
                 max_doc_ratio=args.max_common_ratio,
             )
-        common_subs = filter_common_phrases(common_subs, saved_meta.get("keyword", ""))
+        filtered = filter_common_phrases(raw_subs, saved_meta.get("keyword", ""))[:args.rank_k]
+        total_docs = len(norm_texts) if norm_texts else 1
+        common_subs = [
+            {"text": sub, "count": cnt, "ratio": cnt / total_docs}
+            for sub, cnt in filtered
+        ]
         title_ranks = rank_equal_titles_from_norm(norm_titles, top_k=args.rank_k)
 
         logging.info("Re-aggregated locally from analysis file. rank_k=%d", args.rank_k)
@@ -726,9 +731,12 @@ def main():
         enc = tiktoken.get_encoding("cl100k_base") if args.analysis_mode != 'char' else None
         print(f"共通本文サブ文字列（3～12{unit}, 最長一致・上位{args.rank_k}）:")
         if common_subs:
-            for sub, cnt in common_subs:
+            for item in common_subs:
+                sub = item["text"]
+                cnt = item["count"]
+                ratio = item["ratio"]
                 length = len(sub) if args.analysis_mode == 'char' else len(enc.encode(sub))
-                print(f"[{cnt}件 / {length}{unit}] {repr(sub)}")
+                print(f"[{cnt}件 / {length}{unit} / {ratio:.0%}] {repr(sub)}")
         else:
             print("（該当なし）")
 
@@ -824,30 +832,35 @@ def main():
 
         # 共通本文サブ文字列（3～12文字・最長一致優先）
         if args.analysis_mode == 'char':
-            common_subs = common_substrings_rank_from_norm(
+            raw_subs = common_substrings_rank_from_norm(
                 norm_texts,
                 min_len=3,
                 max_len=12,
-                top_k=args.rank_k,
+                top_k=args.rank_k * 3,
                 max_doc_ratio=args.max_common_ratio,
             )
         elif args.analysis_mode == 'hybrid':
-            common_subs = hybrid_common_rank_from_norm(
+            raw_subs = hybrid_common_rank_from_norm(
                 norm_texts,
                 min_len=3,
                 max_len=12,
-                top_k=args.rank_k,
+                top_k=args.rank_k * 3,
                 max_doc_ratio=args.max_common_ratio,
             )
         else:
-            common_subs = common_tokens_rank_from_norm(
+            raw_subs = common_tokens_rank_from_norm(
                 norm_texts,
                 min_len=3,
                 max_len=12,
-                top_k=args.rank_k,
+                top_k=args.rank_k * 3,
                 max_doc_ratio=args.max_common_ratio,
             )
-        common_subs = filter_common_phrases(common_subs, args.keyword)
+        filtered = filter_common_phrases(raw_subs, args.keyword)[:args.rank_k]
+        total_docs = len(norm_texts) if norm_texts else 1
+        common_subs = [
+            {"text": sub, "count": cnt, "ratio": cnt / total_docs}
+            for sub, cnt in filtered
+        ]
         # SEOタイトルの完全一致ランキング
         title_ranks = rank_equal_titles_from_norm(norm_titles, top_k=args.rank_k)
 
@@ -858,9 +871,12 @@ def main():
         enc = tiktoken.get_encoding("cl100k_base") if args.analysis_mode != 'char' else None
         if common_subs:
             logging.info("Top %d COMMON SUBSTRINGS (len 3-12 %s, longest-match):", len(common_subs), unit_en)
-            for sub, cnt in common_subs:
+            for item in common_subs:
+                sub = item["text"]
+                cnt = item["count"]
+                ratio = item["ratio"]
                 length = len(sub) if args.analysis_mode == 'char' else len(enc.encode(sub))
-                logging.info("[SUB %d] %r (len=%d)", cnt, sub, length)
+                logging.info("[SUB %d / %.0f%%] %r (len=%d)", cnt, ratio * 100, sub, length)
         else:
             logging.info("No common substrings found (len 3-12 %s).", unit_en)
 
@@ -924,9 +940,12 @@ def main():
         enc = tiktoken.get_encoding("cl100k_base") if args.analysis_mode != 'char' else None
         print(f"共通本文サブ文字列（3～12{unit}, 最長一致・上位{args.rank_k}）:")
         if common_subs:
-            for sub, cnt in common_subs:
+            for item in common_subs:
+                sub = item["text"]
+                cnt = item["count"]
+                ratio = item["ratio"]
                 length = len(sub) if args.analysis_mode == 'char' else len(enc.encode(sub))
-                print(f"[{cnt}件 / {length}{unit}] {repr(sub)}")
+                print(f"[{cnt}件 / {length}{unit} / {ratio:.0%}] {repr(sub)}")
         else:
             print("（該当なし）")
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -70,8 +70,8 @@
 
     <h2>Common substrings</h2>
     <ul>
-      {% for sub, cnt in common_subs %}
-        <li>{{ cnt }} docs: {{ sub }}</li>
+      {% for item in common_subs %}
+        <li>{{ item.count }} docs ({{ (item.ratio * 100)|round(1) }}%): {{ item.text }}</li>
       {% endfor %}
     </ul>
 

--- a/webui.py
+++ b/webui.py
@@ -65,19 +65,28 @@ def run_analysis(keyword: str, num_results: int, delay: float, rank_k: int,
                 texts.append(text)
                 titles.append(title)
 
-    common_subs = common_substrings_rank(
+    # まず多めに候補を取得し、フィルタ後に上位 rank_k 件へ絞り込む
+    raw_subs = common_substrings_rank(
         texts,
         analyze_chars=analyze_chars,
-        top_k=rank_k,
+        top_k=rank_k * 3,
         remove_trans=remove_trans,
         remove_patterns=remove_patterns,
         max_doc_ratio=max_common_ratio,
         mode=analysis_mode,
     )
-    common_subs = filter_common_phrases(common_subs, keyword)
-    title_ranks = rank_equal_titles(titles, top_k=rank_k,
-                                   remove_trans=remove_trans,
-                                   remove_patterns=remove_patterns)
+    filtered = filter_common_phrases(raw_subs, keyword)[:rank_k]
+    total_docs = len(texts) if texts else 1
+    common_subs = [
+        {"text": sub, "count": cnt, "ratio": cnt / total_docs}
+        for sub, cnt in filtered
+    ]
+    title_ranks = rank_equal_titles(
+        titles,
+        top_k=rank_k,
+        remove_trans=remove_trans,
+        remove_patterns=remove_patterns,
+    )
     return results, common_subs, title_ranks
 
 


### PR DESCRIPTION
## Summary
- Show document coverage ratios for each common substring in CLI and web UI
- Ensure requested top-k count is maintained by oversampling before filtering
- Display coverage ratios in the HTML template and README examples

## Testing
- `python -m py_compile scraper.py webui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a43a752494832cbd37fe9f88d76b50